### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -23,16 +23,15 @@ jobs:
     - uses: actions/checkout@v3
       name: Checkout
 
-    - uses: golangci/golangci-lint-action@v3
-      name: Lint
-      with:
-        working-directory: ${{matrix.projects}}
-
     - name: Build code
       run: |
         cd ${{matrix.projects}}
-        go mod download
         mkdir go_out
         for CMD in `ls cmd`; do
           go build -o go_out/$CMD cmd/$CMD/main.go
         done
+
+    - uses: golangci/golangci-lint-action@v3
+      name: Lint
+      with:
+        working-directory: ${{matrix.projects}}

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -27,8 +27,9 @@ jobs:
       run: |
         cd ${{matrix.projects}}
         mkdir go_out
-        for CMD in `ls cmd`; do
-          go build -o go_out/$CMD cmd/$CMD/main.go
+        for pkg in `ls cmd`; do
+          echo "Building $pkg"
+          go build -o go_out/$pkg cmd/$pkg/main.go
         done
 
     - uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -1,8 +1,6 @@
 name: Go CI
 
-on:
-- push
-- pull_request
+on: [push]
 
 permissions:
   contents: read

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -15,10 +15,10 @@ jobs:
         projects:
         - aiden_auth
     steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-go@v3
       name: Setup go
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - uses: actions/checkout@v3
       name: Checkout

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/setup-node@v3
       name: Setup go
       with:
-        go-version: 1.19
+        go-version: 1.18
 
     - uses: actions/checkout@v3
       name: Checkout

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -1,0 +1,38 @@
+name: Go CI
+
+on:
+- push
+- pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        projects:
+        - aiden_auth
+    steps:
+    - uses: actions/setup-node@v3
+      name: Setup go
+      with:
+        go-version: 1.19
+
+    - uses: actions/checkout@v3
+      name: Checkout
+
+    - uses: golangci/golangci-lint-action@v3
+      name: Lint
+      with:
+        working-directory: ${{matrix.projects}}
+
+    - name: Build code
+      run: |
+        cd ${{matrix.projects}}
+        go mod download
+        mkdir go_out
+        for CMD in `ls cmd`; do
+          go build -o go_out/$CMD cmd/$CMD/main.go
+        done

--- a/.github/workflows/node-ci.yaml
+++ b/.github/workflows/node-ci.yaml
@@ -1,0 +1,33 @@
+name: Node.js CI
+
+on:
+- push
+- pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        projects:
+        - aiden_auth
+        - aiden_vehicle_hud
+    steps:
+    - uses: actions/checkout@v3
+      name: Checkout
+
+    - uses: actions/setup-node@v3
+      name: Setup node
+      with:
+        node-version: 16
+        cache: yarn
+        cache-dependency-path: ${{matrix.projects}}/yarn.lock
+
+    - name: Change directory
+      run: |
+        cd ${{matrix.projects}}
+        yarn
+        yarn build

--- a/.github/workflows/node-ci.yaml
+++ b/.github/workflows/node-ci.yaml
@@ -1,8 +1,6 @@
 name: Node.js CI
 
-on:
-- push
-- pull_request
+on: [push]
 
 permissions:
   contents: read

--- a/aiden_auth/package.json
+++ b/aiden_auth/package.json
@@ -7,9 +7,7 @@
   "license": "MIT",
   "scripts": {
     "start": "webpack watch --mode development",
-    "build": "yarn build:webpack && yarn build:tsc",
-    "build:webpack": "webpack --mode production",
-    "build:tsc": "tsc src/backend/*.ts --outDir dist/backend"
+    "build": "webpack --mode production"
   },
   "dependencies": {
     "node-fetch": "^3.2.10",


### PR DESCRIPTION
Add CI for Go and Node projects.

To update CI for more projects in the future, just add them to the matrix in each action